### PR TITLE
Fix RunTest#testRunWithScriptInput.

### DIFF
--- a/src/test/resources/SampleScript.sh
+++ b/src/test/resources/SampleScript.sh
@@ -1,6 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 while true;do
-  echo -n ""
   read USERNAME
   if [[ -z $USERNAME ]];then
     break


### PR DESCRIPTION
echo's `-n` parameter isn't defined in `sh`. So, the behavior of echo -n "" can be different for sh and bash.
http://mywiki.wooledge.org/Bashism

An alternate fix would have been to change the command being used in the plugin config to 'bash' from 'sh', but this seems ok too.

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.416 sec
testRunWithScriptInput(co.cask.hydrator.plugin.RunTest)  Time elapsed: 12.271 sec
testRunWithJarInput(co.cask.hydrator.plugin.RunTest)  Time elapsed: 12.49 sec

Results :

Tests run: 6, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:14 min
[INFO] Finished at: 2016-12-15T17:44:27-08:00
[INFO] Final Memory: 66M/591M
[INFO] ------------------------------------------------------------------------
```